### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/profiler/sampler.cc
+++ b/src/profiler/sampler.cc
@@ -210,7 +210,7 @@ void* ThreadKey(pthread_t thread_id) {
 
 // Returns hash value for hash map.
 uint32_t ThreadHash(pthread_t thread_id) {
-#if V8_OS_MACOSX
+#if V8_OS_MACOSX || V8_OS_FREEBSD
   return static_cast<uint32_t>(reinterpret_cast<intptr_t>(thread_id));
 #else
   return static_cast<uint32_t>(thread_id);


### PR DESCRIPTION
```
../src/profiler/sampler.cc:216:10: error: static_cast from 'pthread_t' (aka 'pthread *') to 'uint32_t' (aka 'unsigned int') is not allowed
  return static_cast<uint32_t>(thread_id);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
